### PR TITLE
Create tag

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -5,4 +5,13 @@ class Post < ApplicationRecord
   validates :body, presence: true
 
   has_many :comments, dependent: :destroy
+  has_many :post_tags, dependent: :destroy
+  has_many :tags, through: :post_tags
+
+  def save_tags(tag_names)
+    tag_names.each do |name|
+      tag = Tag.find_or_create_by(name: name)
+      self.tags << tag
+    end
+  end
 end

--- a/app/models/post_tag.rb
+++ b/app/models/post_tag.rb
@@ -1,0 +1,5 @@
+class PostTag < ApplicationRecord
+  belongs_to :post
+  belongs_to :tag
+  validates :tag_id, uniqueness: { scope: :post_id }
+end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,0 +1,5 @@
+class Tag < ApplicationRecord
+  has_many :post_tags, dependent: :destroy
+  has_many :posts, through: :post_tags
+  validates :name, presence: true, uniqueness: true
+end

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -18,6 +18,11 @@
       ], @post.amount), { prompt: "選択してください" }, class: "border p-2 rounded w-full" %>
     </div>
 
+    <div class="mb-4">
+      <label for="tag_names" class="block mb-1 font-medium">タグ</label>
+      <%= text_field_tag :tag_names, @tag_names, class: "w-full p-2 border rounded-md" %>
+    </div>
+
     <!-- 感想 -->
     <div class="mb-4">
       <%= f.label :body, "感想", class: "block font-medium" %><br>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -27,6 +27,17 @@
               <span class="whitespace-pre-line"><%= post.body %></span>
             </p>
 
+            <% if post.tags.any? %>
+              <div class="mb-4">
+                <span class="font-semibold text-gray-700">
+                <% post.tags.each do |tag| %>
+                  <span class="inline-block bg-yellow-400 text-white text-sm px-2 py-1 rounded-full mr-1">
+                    <%= link_to "##{tag.name}", posts_path(tag_name: tag.name), class: "hover:underline" %>
+                  </span>
+                <% end %>
+              </div>
+            <% end %>
+
             <!-- コメントアイコンとコメント数（右下に配置） -->
             <div class="flex items-center text-sm text-gray-500 mt-4">
               <i class="fa-regular fa-message mr-1 text-lg"></i>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -17,6 +17,11 @@
         "10000円以上"
       ]), { prompt: "選択してください" }, class: "border p-2 rounded w-full" %>
     </div>
+
+    <div class="mb-4">
+      <label for="tag_names" class="block font-medium">タグ</label>
+      <%= text_field_tag :tag_names, '', placeholder: "例: 貯金, 習慣化", class: "w-full border p-2 rounded" %>
+    </div>
   
     <!-- 本文 -->
     <div class="mb-4">

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -28,6 +28,17 @@
           <span class="whitespace-pre-line"><%= @post.body %></span>
         </p>
 
+        <% if @post.tags.any? %>
+          <div class="mb-4">
+            <span class="font-semibold text-gray-700"></span>
+            <% @post.tags.each do |tag| %>
+              <span class="inline-block bg-yellow-400 text-white text-sm px-2 py-1 rounded-full mr-1">
+                <%= link_to "##{tag.name}", posts_path(tag_name: tag.name), class: "hover:underline" %>
+              </span>
+            <% end %>
+          </div>
+        <% end %>
+
         <!-- 編集・削除リンク（投稿者のみ） -->
         <% if current_user == @post.user %>
           <div class="flex justify-end space-x-2 mt-4">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
   end
 
   resources :posts do
+    get :tags, on: :collection
     resources :comments, only: [ :create, :edit, :destroy, :update ], shallow: true
   end
 

--- a/db/migrate/20250425095103_create_tags.rb
+++ b/db/migrate/20250425095103_create_tags.rb
@@ -1,0 +1,10 @@
+class CreateTags < ActiveRecord::Migration[7.2]
+  def change
+    create_table :tags do |t|
+      t.string :name, null: false
+
+      t.timestamps
+    end
+    add_index :tags, :name, unique: true
+  end
+end

--- a/db/migrate/20250425095256_create_post_tags.rb
+++ b/db/migrate/20250425095256_create_post_tags.rb
@@ -1,0 +1,11 @@
+class CreatePostTags < ActiveRecord::Migration[7.2]
+  def change
+    create_table :post_tags do |t|
+      t.references :post, null: false, foreign_key: true
+      t.references :tag, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :post_tags, [ :post_id, :tag_id ], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_04_23_003430) do
+ActiveRecord::Schema[7.2].define(version: 2025_04_25_095256) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -33,6 +33,16 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_23_003430) do
     t.index ["user_id"], name: "index_goals_on_user_id"
   end
 
+  create_table "post_tags", force: :cascade do |t|
+    t.bigint "post_id", null: false
+    t.bigint "tag_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["post_id", "tag_id"], name: "index_post_tags_on_post_id_and_tag_id", unique: true
+    t.index ["post_id"], name: "index_post_tags_on_post_id"
+    t.index ["tag_id"], name: "index_post_tags_on_tag_id"
+  end
+
   create_table "posts", force: :cascade do |t|
     t.string "amount"
     t.text "body"
@@ -48,6 +58,13 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_23_003430) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["goal_id"], name: "index_savings_on_goal_id"
+  end
+
+  create_table "tags", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_tags_on_name", unique: true
   end
 
   create_table "users", force: :cascade do |t|
@@ -68,6 +85,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_23_003430) do
   add_foreign_key "comments", "posts"
   add_foreign_key "comments", "users"
   add_foreign_key "goals", "users"
+  add_foreign_key "post_tags", "posts"
+  add_foreign_key "post_tags", "tags"
   add_foreign_key "posts", "users"
   add_foreign_key "savings", "goals"
 end

--- a/test/fixtures/post_tags.yml
+++ b/test/fixtures/post_tags.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  post: one
+  tag: one
+
+two:
+  post: two
+  tag: two

--- a/test/fixtures/tags.yml
+++ b/test/fixtures/tags.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+
+two:
+  name: MyString

--- a/test/models/post_tag_test.rb
+++ b/test/models/post_tag_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class PostTagTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/tag_test.rb
+++ b/test/models/tag_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class TagTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# 概要
今回は、投稿にタグ付けできるようにしました。

## 内容
①Tagモデル作成。
②タグモデルと投稿モデルは多対多のため中間モデル（Post_tag）を作成。
③同じ名前のタグはデータの膨張になるため既存のタグを使用するようそれぞれのマイグレーションファイルに処理記述。
④view/Post/index.edit.show.newにそれぞれタグを作成・編集閲覧できるように修正。

Closes #21 